### PR TITLE
fix(action): use quotes in condition to respect multiline strings (e.g. ssh key)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,9 +43,9 @@ runs:
       if: steps.poetry-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        if [ ! -z ${{ inputs.ssh_key }} ]; then
+        if [ ! -z "${{ inputs.ssh_key }}" ]; then
             eval "$(ssh-agent -s)"
-            bash -c 'ssh-add - <<< "${{ inputs.ssh_key }}"'
+            ssh-add - <<< "${{ inputs.ssh_key }}"
         fi
 
         poetry install


### PR DESCRIPTION
This PR fixes the problem by providing a multiline string (e.g. ssh key) to install private git dependencies.