### PR TITLE
feat(action): update source of Poetry installation script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Install and configure Poetry
       shell: bash
       run: |
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - --yes --version=${{ inputs.poetry_version }}
+        curl -sSL https://install.python-poetry.org | python - --yes --version=${{ inputs.poetry_version }}
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
     - name: Restore virtualenv from Poetry cache


### PR DESCRIPTION
It is recommended to update the source of the Poetry installation script.

I found this message in our CI logfiles

`
The canonical source for Poetry's installation script is now https://install.python-poetry.org. Please update your usage to reflect this.
`

Docs: https://python-poetry.org/docs/master/
