### PR TITLE
feat(action): fail pipeline if poetry.lock is not up to date

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,12 @@ runs:
         path: ~/.cache/pypoetry/virtualenvs
         key: poetry-${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
 
+    # ToDo: replace with `poetry lock --check` after upgrade to Poetry 1.2.X
+    - name: Check poetry.lock is up to date with pyproject.toml
+      run: |
+        exit $(poetry export -o requirements.txt | grep "Warning: The lock file is not up to date with the latest changes in pyproject.toml." | wc -l)
+      shell: bash
+
     - name: Create virtualenv and install dependencies
       if: steps.poetry-cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
This action can be updated and moved to our new actions repository https://github.com/moneymeets/moneymeets-composite-actions.
But we need to update all our repositories. I'll put it on my list.

This PR will check if the lock file is up to date with the latest changes in `pyproject.toml`. In the new version of Poetry (1.2.x), which is in beta, there is a command for this. `poetry lock --check`