### PR TITLE
Feature/bump versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -33,7 +33,7 @@ runs:
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
     - name: Restore virtualenv from Poetry cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: poetry-cache
       with:
         path: ~/.cache/pypoetry/virtualenvs

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: true
-    default: "3.10.4"
+    default: "3.10.6"
   ssh_key:
     description: "SSH key to use to clone private repositories"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   ssh_key:
     description: "SSH key to use to clone private repositories"
     required: false
+  poetry_virtualenvs_path:
+    description: "Poetry virtualenvs path"
+    required: false
+    default: "/home/runner/.cache/pypoetry/virtualenvs"
 
 outputs:
   python-version:
@@ -36,7 +40,7 @@ runs:
       uses: actions/cache@v3
       id: poetry-cache
       with:
-        path: ~/.cache/pypoetry/virtualenvs
+        path: ${{ inputs.poetry_virtualenvs_path }}
         key: poetry-${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
 
     - run: poetry lock --check
@@ -45,6 +49,8 @@ runs:
     - name: Create virtualenv and install dependencies
       if: steps.poetry-cache.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        POETRY_VIRTUALENVS_PATH: ${{ inputs.poetry_virtualenvs_path }}
       run: |
         if [ ! -z "${{ inputs.ssh_key }}" ]; then
             eval "$(ssh-agent -s)"

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   poetry_version:
     description: "Poetry version to install"
     required: true
-    default: "1.1.13"
+    default: "1.2.0"
   python_version:
     description: "Python version to use"
     required: true
@@ -39,10 +39,7 @@ runs:
         path: ~/.cache/pypoetry/virtualenvs
         key: poetry-${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
 
-    # ToDo: replace with `poetry lock --check` after upgrade to Poetry 1.2.X
-    - name: Check poetry.lock is up to date with pyproject.toml
-      run: |
-        exit $(poetry export -o requirements.txt | grep "Warning: The lock file is not up to date with the latest changes in pyproject.toml." | wc -l)
+    - run: poetry lock --check
       shell: bash
 
     - name: Create virtualenv and install dependencies


### PR DESCRIPTION
In this PR I've updated the default Poetry version to 1.2.0. @felix11h tested the Version and it is already updated in our Heroku buildpack. You can use the new version with old lockfile.
Furthermore the default Python version is updated to 3.10.6. All repositories except APIs are using this. The pipelines of APIs repositories are pinned to Python 3.10.5 and needs to be updated by hand.

@zyv @mm-matthias FYI