### PR TITLE
feat(actions): add possibility to override working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Poetry virtualenvs path"
     required: false
     default: "/home/runner/.cache/pypoetry/virtualenvs"
+  working_directory:
+    description: "Working directory, defaults to GITHUB_WORKSPACE"
+    required: false
+    default: ${{ github.workspace }}
 
 outputs:
   python-version:
@@ -44,11 +48,12 @@ runs:
         key: poetry-${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
 
     - run: poetry lock --check
-      shell: bash
+      working-directory: ${{ inputs.working_directory }}
 
     - name: Create virtualenv and install dependencies
       if: steps.poetry-cache.outputs.cache-hit != 'true'
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       env:
         POETRY_VIRTUALENVS_PATH: ${{ inputs.poetry_virtualenvs_path }}
       run: |


### PR DESCRIPTION
Needed for fixing https://github.com/moneymeets/action-beanstalk-deploy/issues/21.

If no working directory is set for your step, the GitHub default is used, which is `GITHUB_WORKSPACE`. For all our CI pipelines this is working, because this working directory is our checkout directory which includes the `pyproject.toml`.

But if you are using `action-setup-python-poetry` in another GitHub action like `action-beanstalk-deploy`, the working directory should be the one from the action itself to install correct dependencies and prevent errors like described in the issue. To achive this, we need to pass the working directory to this action to be able to override it.
