### PR TITLE
fix(action): add missing shell property

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ runs:
         key: poetry-${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock', '**/pyproject.toml') }}
 
     - run: poetry lock --check
+      shell: bash
       working-directory: ${{ inputs.working_directory }}
 
     - name: Create virtualenv and install dependencies


### PR DESCRIPTION
The property is required, after all. https://github.com/moneymeets/action-beanstalk-deploy/actions/runs/3938232394/jobs/6736684453 I should have double-checked this...

I will merge it right away, so that our CI pipelines are not blocked.