### PR TITLE
feat(action): bump default Poetry to 1.5.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   poetry_version:
     description: "Poetry version to install"
     required: true
-    default: "1.4.1"
+    default: "1.5.1"
   python_version:
     description: "Python version to use"
     required: true


### PR DESCRIPTION
Matching https://github.com/moneymeets/python-poetry-buildpack/pull/62.