### PR TITLE
feat(action): add option to disable setup python cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "Working directory, defaults to GITHUB_WORKSPACE"
     required: false
     default: ${{ github.workspace }}
+  # ToDo: Remove disable cache option when https://github.com/actions/setup-python/issues/361 is fixed
+  poetry_cache_enabled:
+    description: "Caching of Poetry environment"
+    default: "true"
 
 outputs:
   python-version:
@@ -56,8 +60,9 @@ runs:
       id: setup-python
       with:
         python-version: '${{ steps.detect-versions.outputs.python-version }}'
-        cache: 'poetry'
-        cache-dependency-path: ${{ inputs.working_directory }}/poetry.lock
+        # ToDo: Remove conditional expressions below when https://github.com/actions/setup-python/issues/361 is fixed
+        cache: ${{ inputs.poetry_cache_enabled == 'true' && 'poetry' || ''}}
+        cache-dependency-path: ${{ inputs.poetry_cache_enabled == 'true' && format('{0}/poetry.lock', inputs.working_directory) || ''}}
 
     - run: |
         if [ "$(echo ${{ steps.detect-versions.outputs.poetry-version }} | cut -c1-4)" == "1.5." ]; then


### PR DESCRIPTION
These changes allow our merge-checks action to use action-setup-python-poetry, see https://github.com/moneymeets/action-merge-checks/pull/31. 

Caching in setup-python needs to be disabled for merge-checks, as we run into the issue described here, https://github.com/actions/setup-python/issues/361, when we use `github.action_path` as the working directory.

Test:
 - ci.yml in moneymeets-pulumi https://github.com/moneymeets/moneymeets-pulumi/actions/runs/6654196980/job/18081746536