### PR TITLE
feat(action): use setup python action v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: pipx install poetry==${{ steps.detect-versions.outputs.poetry-version }}
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       id: setup-python
       with:
         python-version: '${{ steps.detect-versions.outputs.python-version-constraint }}'


### PR DESCRIPTION
Upgrading to v5 to use Node version 20, see also https://github.com/actions/setup-python/releases.

This should get rid of the final warning in moneymeets-tenants, @pchorus (e.g. https://github.com/moneymeets/moneymeets-tenants/actions/runs/7885323524, see also https://github.com/moneymeets/moneymeets-tenants/pull/753)