### PR TITLE
fix(action): use correct path to check invalid package versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
         cache: ${{ inputs.poetry_cache_enabled == 'true' && 'poetry' || ''}}
         cache-dependency-path: ${{ inputs.poetry_cache_enabled == 'true' && format('{0}/poetry.lock', inputs.working_directory) || ''}}
 
-    - run: python ${{ github.action_path }}/invalid_package_versions/runner.py
+    - run: poetry run --directory ${{ github.action_path }} invalid_package_versions
       shell: bash
       working-directory: ${{ inputs.working_directory }}
 

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
         cache: ${{ inputs.poetry_cache_enabled == 'true' && 'poetry' || ''}}
         cache-dependency-path: ${{ inputs.poetry_cache_enabled == 'true' && format('{0}/poetry.lock', inputs.working_directory) || ''}}
 
-    - run: python ${{ github.action_path }}/invalid-package-versions.py
+    - run: python ${{ github.action_path }}/invalid_package_versions/runner.py
       shell: bash
       working-directory: ${{ inputs.working_directory }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["moneymeets GmbH <service@moneymeets.com>"]
 
 
 [tool.poetry.scripts]
-merge_checks_runner = 'invalid_package_versions.runner:run'
+invalid_package_versions = 'invalid_package_versions.runner:run'
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
As you can see in https://github.com/moneymeets/moneymeets-tenants/actions/runs/8687316068, the script cannot be found.
We introduced unittests and created a python package and missed to update the path in `action.yml`.

This should fix the problem.