### PR TITLE
fix(action): fix outdated dev-dependencies section handling

### DIFF
--- a/action_setup_python_poetry/invalid_package_versions.py
+++ b/action_setup_python_poetry/invalid_package_versions.py
@@ -20,7 +20,7 @@ def get_invalid_package_versions(pyproject_toml_file_text: str) -> Sequence[tupl
         (package, version_str)
         for package, version in (
             *poetry_data["dependencies"].items(),
-            *poetry_data["dev-dependencies"].items(),
+            *poetry_data.get("dev-dependencies", {}).items(),
             *itertools.chain.from_iterable(
                 (group["dependencies"].items() for _, group in poetry_data.get("group", {}).items()),
             ),

--- a/action_setup_python_poetry/tests/data/pyproject_mock_no_dev_dependencies.toml
+++ b/action_setup_python_poetry/tests/data/pyproject_mock_no_dev_dependencies.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "test-project"
+version = "0.1.0"
+description = "Testing only"
+authors = ["moneymeets GmbH <service@moneymeets.com>"]
+
+[tool.poetry.scripts]
+merge_checks_runner = 'invalid_package_versions.runner:run'
+
+[tool.poetry.dependencies]
+python = "~3.12"
+
+[tool.poetry.group.test-group-1.dependencies]
+test-package-1 = "*"
+
+[tool.poetry.group.test-group-2.dependencies]
+test-package-2 = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/action_setup_python_poetry/tests/test_get_invalid_package_versions.py
+++ b/action_setup_python_poetry/tests/test_get_invalid_package_versions.py
@@ -7,13 +7,12 @@ TEST_DATA_DIR = Path(__file__).parent / "data"
 
 
 class GetInvalidPackageVersionsTest(TestCase):
-    valid_pyproject_toml = (TEST_DATA_DIR / "pyproject_mock_valid.toml").read_text()
-    invalid_pyproject_toml = (TEST_DATA_DIR / "pyproject_mock_invalid.toml").read_text()
-
     def test_get_invalid_package_versions_success(self):
-        self.assertEqual((), get_invalid_package_versions(self.valid_pyproject_toml))
+        valid_pyproject_toml = (TEST_DATA_DIR / "pyproject_mock_valid.toml").read_text()
+        self.assertEqual((), get_invalid_package_versions(valid_pyproject_toml))
 
     def test_get_invalid_package_versions_failed(self):
+        invalid_pyproject_toml = (TEST_DATA_DIR / "pyproject_mock_invalid.toml").read_text()
         self.assertEqual(
             (
                 ("python", ">=3.12"),
@@ -21,5 +20,9 @@ class GetInvalidPackageVersionsTest(TestCase):
                 ("test-package-1", ">=1"),
                 ("test-package-2", ">=1"),
             ),
-            get_invalid_package_versions(self.invalid_pyproject_toml),
+            get_invalid_package_versions(invalid_pyproject_toml),
         )
+
+    def test_no_dev_dependencies(self):
+        no_dev_dependencies_pyproject_toml = (TEST_DATA_DIR / "pyproject_mock_no_dev_dependencies.toml").read_text()
+        self.assertEqual((), get_invalid_package_versions(no_dev_dependencies_pyproject_toml))


### PR DESCRIPTION
I use `action-setup-python-poetry` in my personal project and I got the following error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/work/_actions/moneymeets/action-setup-python-poetry/master/action_setup_python_poetry/invalid_package_versions.py", line 34, in main
    if invalid_versions := get_invalid_package_versions(pyproject_path.read_text()):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/moneymeets/action-setup-python-poetry/master/action_setup_python_poetry/invalid_package_versions.py", line 23, in get_invalid_package_versions
    *poetry_data["dev-dependencies"].items(),
     ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'dev-dependencies'
```
The reason is that `dev-dependencies` is no longer used since poetry 1.2. If you create a new `pyproject.toml` now, it won't contain `dev-dependencies` section anymore.