### PR TITLE
fix(action): separate Python setup for action and repository use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,18 +39,42 @@ runs:
     - uses: moneymeets/moneymeets-composite-actions/block-poetry-version-downgrade@master
       if: ${{ inputs.with_checks == 'true' }}
 
-    - uses: moneymeets/moneymeets-composite-actions/detect-python-version@master
+    - name: Detect Python and Poetry versions for repository
+      uses: moneymeets/moneymeets-composite-actions/detect-python-version@master
       id: detect-versions
       with:
         poetry_version: ${{ inputs.poetry_version }}
         python_version: ${{ inputs.python_version }}
         working_directory: ${{ inputs.working_directory }}
 
+    - name: Detect Python and Poetry versions for action
+      uses: moneymeets/moneymeets-composite-actions/detect-python-version@master
+      id: detect-versions-action
+      with:
+        working_directory: ${{ github.action_path }}
+
     - name: Install and configure Poetry
       shell: bash
       run: pipx install poetry==${{ steps.detect-versions.outputs.poetry-version }}
 
-    - uses: actions/setup-python@v5
+    - name: Setup Python for action
+      uses: actions/setup-python@v5
+      id: setup-python-action
+      with:
+        python-version: '${{ steps.detect-versions-action.outputs.python-version-constraint }}'
+        # ToDo: Enable when https://github.com/actions/setup-python/issues/361 is fixed
+        # cache: 'poetry'
+        # cache-dependency-path: ${{ format('{0}/poetry.lock', github.action_path) }}
+
+    - name: Check for invalid package versions in pyproject.toml
+      run: |
+        poetry install
+        poetry run invalid_package_versions ${{ inputs.working_directory }}/pyproject.toml
+      shell: bash
+      working-directory: ${{ github.action_path }}
+
+    - name: Setup Python for repository
+      uses: actions/setup-python@v5
       id: setup-python
       with:
         python-version: '${{ steps.detect-versions.outputs.python-version-constraint }}'
@@ -66,13 +90,6 @@ runs:
         fi
       shell: bash
       working-directory: ${{ inputs.working_directory }}
-
-    - name: Check for invalid package versions in pyproject.toml
-      run: |
-        poetry install
-        poetry run invalid_package_versions ${{ inputs.working_directory }}/pyproject.toml
-      shell: bash
-      working-directory: ${{ github.action_path }}
 
     - name: Create virtualenv and install dependencies
       shell: bash


### PR DESCRIPTION
Repository and action can possibly use different valid Python versions (like `~3.11` and `~3.12`). Since you introduced Python setup for the internal needs of the action itself, it broke the usage of the action in such repositories, because it now implicitly assumes that both Python versions will always match.

I would separate the setup of two Python interpreters to support different Python versions for repositories and action, because in practice both versions will probably come from the toolcache and setup will take only a few milliseconds anyways - but it will help during version upgrades.