### PR TITLE
fix(action): constrain virtualenv version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,10 @@ runs:
 
     - name: Install and configure Poetry
       shell: bash
-      run: pipx install poetry==${{ steps.detect-versions.outputs.poetry-version }}
+      run: |
+        echo "virtualenv==20.32.0" > constraints.txt
+        pipx install poetry==${{ steps.detect-versions.outputs.poetry-version }} --pip-args="--constraint=constraints.txt"
+        rm constraints.txt
 
     - name: Setup Python for action
       uses: actions/setup-python@v5


### PR DESCRIPTION
Using the workaround described here https://github.com/python-poetry/poetry/issues/10490 to get our pipelines running again.

Once this is fixed on Poetry side, this can (and should) be removed again. I will make a ticket for this.

@catcombo, your pull request in insurance-api is running successfully with this fix, see https://github.com/moneymeets/django-insurance-api-v2/actions/runs/16716638335/job/47311361659. So, once this is merged here, your pull request should be able to go through as well.