### PR TITLE
feat(action): remove virtualenv version constraint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,10 +55,7 @@ runs:
 
     - name: Install and configure Poetry
       shell: bash
-      run: |
-        echo "virtualenv==20.32.0" > constraints.txt
-        pipx install poetry==${{ steps.detect-versions.outputs.poetry-version }} --pip-args="--constraint=constraints.txt"
-        rm constraints.txt
+      run: pipx install poetry==${{ steps.detect-versions.outputs.poetry-version }}
 
     - name: Setup Python for action
       uses: actions/setup-python@v5


### PR DESCRIPTION
This removes the fix that was introduced in #40, as the constraint to virtualenv is now implemented in the latest version of Poetry directly, https://github.com/python-poetry/poetry/releases/tag/2.1.4.

Some additional notes:

- Once this pull request is merged, many pipelines will fail again. To fix this, in each repository, the Poetry version will need to be upgraded to version 2.1.4 or greater. Our automatic Python dependencies updater (https://github.com/moneymeets/action-poetry-update) can be used to do this in repositories which use the action.
- _(Note that pipelines in some repositories run successfully without the fix, for example, this repository here. This is because, by chance, the latest Ubuntu version we are using in workflows here happens to have a matching Python version of 3.12. In insurance-api, however, we are still using Ubuntu 22.04 in the CI workflow leading to incompatible Python versions.)_

Testing:
 - Updated action with Poetry version 2.13, Ubuntu 22.04 https://github.com/moneymeets/django-insurance-api-v2/commit/97d0bff9c6ff4767391d34f8ad2c54281586891b (fail)
 - Updated action with Poetry version 2.14, Ubuntu 22.04 https://github.com/moneymeets/django-insurance-api-v2/commit/87d051f82f4838249263a7b21ce8f916677ee6f9 (success)
 - Updated action with Poetry version 2.13, Ubuntu 24.04 https://github.com/moneymeets/django-insurance-api-v2/commit/bc0024d77f4522e6c803a4b77ba0e238c19b9d8d (success) 

ToDo
- [ ] remove test branch `feature/test-poetry-fix` in insurance-api